### PR TITLE
fix admin-signout-path

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -24,4 +24,7 @@ class Admin::SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+  def after_sign_out_path_for(resource)
+    new_admin_session_path
+  end
 end


### PR DESCRIPTION
### app/controllers/admin/sessions_controller.rb

- 作成したadmin/sessions_controller.rbに対してオーバーライドを行いました。
 ```
def after_sign_out_path_for(resource)   
  new_admin_session_path  
end
```