### PR TITLE
Fix Routing-fix

### DIFF
--- a/app/views/admins/sessions/new.html.erb
+++ b/app/views/admins/sessions/new.html.erb
@@ -22,5 +22,3 @@
     <%= f.submit "Log in" %>
   </div>
 <% end %>
-
-<%= render "admins/shared/links" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,5 @@
 Rails.application.routes.draw do
-#only等は未着手resourcesで大体のアクションができるか確認
 #deviseの設定
-#devise_for :admins, path: 'admin', controllers: {
-#    sessions: 'admin/sessions'
-#  }
 devise_for :admins, skip: :all
 devise_scope :admin do
     get '/admin/sign_in' => 'admin/sessions#new', as: :new_admin_session

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,15 @@
 Rails.application.routes.draw do
 #only等は未着手resourcesで大体のアクションができるか確認
 #deviseの設定
-devise_for :admins, path: 'admin', controllers: {
-    sessions: 'admin/sessions'
-  }
+#devise_for :admins, path: 'admin', controllers: {
+#    sessions: 'admin/sessions'
+#  }
+devise_for :admins, skip: :all
+devise_scope :admin do
+    get '/admin/sign_in' => 'admin/sessions#new', as: :new_admin_session
+    post '/admin/sign_in' => 'admin/sessions#create', as: :admin_session
+    delete '/admin/sign_out' => 'admin/sessions#destroy', as: :destroy_admin_session
+end
 devise_for :customers, skip: :all
 devise_scope :customer do
     get '/customers/sign_in' => 'public/sessions#new', as: :new_customer_session


### PR DESCRIPTION
### app/views/admins/sessions/new.html.erb

- <%= render "admins/shared/links" %>が表示されるとエラーが出るので削除

### config/routes.rb
```
devise_for :admins, skip: :all
```
この設定でcurrent_adminなどを使える状況にしつつ、すべてのルーティングをいったんスキップにします。

```
devise_scope :admin do    
  get '/admin/sign_in' =&gt; 'admin/sessions#new', as: :new_admin_session
  post '/admin/sign_in' =&gt; 'admin/sessions#create', as: :admin_session
  delete '/admin/sign_out' =&gt; 'admin/sessions#destroy', as: :destroy_admin_session
end
```
セッション関連のみに絞り込み

